### PR TITLE
Update calendar: embed Luma calendar and replace hardcoded date

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,18 @@
   font-weight: 600;
 }
 
+.meetup-date-link {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+}
+
+.meetup-date-link:hover {
+  opacity: 0.8;
+}
+
 .cta-button {
   display: inline-block;
   background: white;
@@ -258,6 +270,40 @@
   font-style: italic;
 }
 
+/* Calendar Section */
+.calendar {
+  padding: var(--spacing-xl) 0;
+  background: var(--boulder-snow);
+  text-align: center;
+}
+
+.calendar h2 {
+  color: var(--boulder-mountain);
+  margin-bottom: var(--spacing-md);
+}
+
+.calendar-description {
+  font-size: 1.25rem;
+  color: var(--text-secondary);
+  max-width: 700px;
+  margin: 0 auto var(--spacing-lg);
+}
+
+.calendar-embed {
+  display: flex;
+  justify-content: center;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.calendar-embed iframe {
+  max-width: 100%;
+  width: 100%;
+  max-width: 600px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
 /* Footer */
 .footer {
   padding: var(--spacing-md) 0;
@@ -330,5 +376,9 @@
   
   .process-item {
     text-align: left;
+  }
+  
+  .calendar-embed iframe {
+    height: 350px;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
           <div className="hero-cta">
             <div className="next-meetup">
               <span className="meetup-label">Next Gathering</span>
-              <span className="meetup-date">Tuesday, July 29th • 6:30 PM</span>
+              <a href="#calendar" className="meetup-date-link">View Calendar →</a>
             </div>
             <a 
               href="https://lu.ma/boulder-builders" 
@@ -140,6 +140,29 @@ const App: React.FC = () => {
             Every Boulder Builders meetup is unique, but we always teach practical skills 
             and help you learn to use technology to bring your visions to life.
           </p>
+        </div>
+      </section>
+
+      {/* Calendar Section */}
+      <section id="calendar" className="calendar">
+        <div className="container">
+          <h2>Upcoming Events</h2>
+          <p className="calendar-description">
+            Join us at our next gathering! All events are free and open to everyone.
+          </p>
+          <div className="calendar-embed">
+            <iframe
+              src="https://lu.ma/embed/calendar/cal-ZCWMKx1NMCXGd7v/events"
+              width="600"
+              height="450"
+              frameBorder="0"
+              style={{border: "1px solid #bfcbda88", borderRadius: "4px"}}
+              allowFullScreen={true}
+              aria-hidden="false"
+              tabIndex={0}
+              title="Boulder Builders Events Calendar"
+            />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Fixes #3

This PR replaces the hardcoded meetup date with an embedded Luma calendar as requested in the issue.

## Changes
- Replace hardcoded meetup date in hero section with 'View Calendar →' link
- Add new calendar section with embedded Luma iframe after Join section
- Add responsive styling for calendar embed
- Link from hero section scrolls to calendar section below

Generated with [Claude Code](https://claude.ai/code)